### PR TITLE
Updated linebreaks in caption separators to prevent warning

### DIFF
--- a/apa7/apa7.dtx
+++ b/apa7/apa7.dtx
@@ -4,11 +4,11 @@
 %                                                                           %
 %    CHANGE THESE VALUES WITH EACH NEW RELEASE:                             %
 %                                                                           %
-%<class>\ProvidesClass{apa7}[2021/03/04 v2.10 APA formatting (7th edition)]
+%<class>\ProvidesClass{apa7}[2021/04/05 v2.11 APA formatting (7th edition)]
 %                                                                           %
 %<*internal>                                                                %
-\def\apaSevenVersionDate{2021/03/04}
-\def\apaSevenVersionNumber{2.10}
+\def\apaSevenVersionDate{2021/04/05}
+\def\apaSevenVersionNumber{2.11}
 %                                                                           %
 %                                                                           %
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -268,6 +268,8 @@ and the derived files           apa7.ins,
 % \changes{v2.09}{2021/03/03}{Updated APA7endfloat.cfg file to use more modern DeclareDelayedFloatFlavor. This fixes the bug where longtable can be shown on the same page as another table. }
 %
 % \changes{v2.10}{2021/03/04}{Update BibLaTex instructions to remove DeclareLanguageMapping and remove commands that are no longer required. }
+%
+% \changes{v2.11}{2021/04/05}{Updated linebreaks in caption separators to prevent warning. }
 %
 % \begin{abstract}
 %   The \textit{Publication Manual} of the American Psychological
@@ -1844,12 +1846,12 @@ and the derived files           apa7.ins,
     \DeclareCaptionLabelFormat{tablelabel}{\hspace{-\parindent}\raggedright\textbf{#1 #2}}
     \DeclareCaptionLabelFormat{figurelabel}{\hspace{-\parindent}\raggedright\textbf{#1 #2}}
     \DeclareCaptionTextFormat{tabletext}{\hspace{-\parindent}\textit{#1}}
-    \DeclareCaptionLabelSeparator{apalabelsep}{\\ \\} 
+    \DeclareCaptionLabelSeparator{apalabelsep}{\\[\baselineskip]} 
 }{% doc
     \DeclareCaptionLabelFormat{tablelabel}{\hspace{-\parindent}\raggedright\textbf{#1 #2}}
     \DeclareCaptionLabelFormat{figurelabel}{\hspace{-\parindent}\raggedright\textbf{#1 #2}}
     \DeclareCaptionTextFormat{tabletext}{\hspace{-\parindent}\raggedright\textit{#1}}
-    \DeclareCaptionLabelSeparator{apalabelsep}{\\ \\} 
+    \DeclareCaptionLabelSeparator{apalabelsep}{\\[\baselineskip]} 
 }
 \captionsetup[table]{position=above,skip=0pt,labelformat=tablelabel,labelsep=apalabelsep,textformat=tabletext}
 \captionsetup[figure]{position=above,skip=0pt,labelformat=figurelabel,labelsep=apalabelsep,textfont=it}


### PR DESCRIPTION
Resolved stack exchange issue [here](https://tex.stackexchange.com/questions/586679/theres-no-line-here-to-end-figure-caption-apa7-documentclass-overleaf)